### PR TITLE
[CPU] Add Addressing Modes #21

### DIFF
--- a/src/main/java/dev/omatheusmesmo/selfmat/nes/emulator/core/cpu/CPU.java
+++ b/src/main/java/dev/omatheusmesmo/selfmat/nes/emulator/core/cpu/CPU.java
@@ -33,6 +33,8 @@ public class CPU {
     public static final int BITS_PER_BYTE = 8;
     public static final int INITIAL_VALUE = 0;
     public static final int MAX_ADDRESS_VALUE = 0xFFFF;
+    public static final int SIGNED_BYTE_MAX = 0x7F;
+    public static final int BYTE_WRAP = 0x100;
 
     public CPU(Bus bus) {
         this.bus = bus;
@@ -88,6 +90,8 @@ public class CPU {
             throw new IllegalStateException(String.format("Unknown opcode: 0x%02X at PC: 0x%04X", opcode, programCounter - 1));
         }
 
+        int address = resolveAddress(metadata.addressingMode());
+
         return metadata.cycles();
     }
 
@@ -96,4 +100,73 @@ public class CPU {
         programCounter= (programCounter + 1) & MAX_ADDRESS_VALUE; // Wrap around 16-bit address space
         return data;
     }
+
+    private int resolveAddress(AddressingMode addressingMode) {
+        return switch (addressingMode) {
+            case IMMEDIATE -> {
+                int address = programCounter;
+                programCounter = (programCounter + 1) & MAX_ADDRESS_VALUE;
+                yield address;
+            }
+            case ZERO_PAGE -> {
+                yield fetch() & BYTE_MASK;
+            }
+            case ABSOLUTE -> {
+                int lo = fetch() & BYTE_MASK;
+                int hi = fetch() & BYTE_MASK;
+                yield (hi << BITS_PER_BYTE) | lo;
+            }
+            case ZERO_PAGE_X -> {
+                int base = fetch() & BYTE_MASK;
+                yield (base + indexX) & BYTE_MASK;
+            }
+            case ZERO_PAGE_Y -> {
+                int base = fetch() & BYTE_MASK;
+                yield (base + indexY) & BYTE_MASK;
+            }
+            case ABSOLUTE_X -> {
+                int lo = fetch() & BYTE_MASK;
+                int hi = fetch() & BYTE_MASK;
+                yield (((hi << BITS_PER_BYTE) | lo) + indexX) & MAX_ADDRESS_VALUE;
+            }
+            case  ABSOLUTE_Y -> {
+                int lo = fetch() & BYTE_MASK;
+                int hi = fetch() & BYTE_MASK;
+                yield (((hi << BITS_PER_BYTE) | lo) + indexY) & MAX_ADDRESS_VALUE;
+            }
+            case RELATIVE -> {
+                int offset = fetch() & BYTE_MASK;
+                if (offset > SIGNED_BYTE_MAX) offset -= BYTE_WRAP; // sign-extend 8-bit offset
+                yield (programCounter + offset) & MAX_ADDRESS_VALUE;
+            }
+            case INDIRECT -> {
+                int pointerLo = fetch() & BYTE_MASK;
+                int pointerHi = fetch() & BYTE_MASK;
+                int pointer = (pointerHi << BITS_PER_BYTE) | pointerLo;
+                // 6502 bug: if the low byte of the pointer is 0xFF, it wraps around to the start of the page
+                int effectiveLo = read(pointer) & BYTE_MASK;
+                int effectiveHi = read((pointer & BYTE_MASK) | ((pointer + 1) & BYTE_MASK)) & BYTE_MASK;
+                yield (effectiveHi << BITS_PER_BYTE) | effectiveLo;
+            }
+            case  INDIRECT_INDEXED -> {
+                int pointer = fetch() & BYTE_MASK;
+                int baseLo = read(pointer) & BYTE_MASK;
+                int baseHi = read(pointer + 1) & BYTE_MASK;
+                int baseAddress = (baseHi << BITS_PER_BYTE) | baseLo;
+                yield (baseAddress + indexY) & MAX_ADDRESS_VALUE;
+            }
+            case INDEXED_INDIRECT -> {
+                int pointer = (fetch() + indexX) & BYTE_MASK;
+                int effectiveLo = read(pointer) & BYTE_MASK;
+                int effectiveHi = read(pointer + 1) & BYTE_MASK;
+                yield (effectiveHi << BITS_PER_BYTE) | effectiveLo;
+            }
+            // IMPLIED, ACCUMULATOR etc. would be handled in instruction execution logic
+            default -> INITIAL_VALUE;
+        };
+
+
+    }
+
+
 }


### PR DESCRIPTION
Fix #21 

# Summary (Copilot)

This pull request introduces a new address resolution mechanism to the `CPU` class, improving how the NES emulator handles various addressing modes. The main change is the addition of the `resolveAddress` method, which centralizes and standardizes address calculation for instructions, supporting all relevant NES addressing modes. This refactor enhances code clarity, maintainability, and accuracy, especially for instructions requiring complex address logic.

Addressing mode resolution improvements:

* Added the `resolveAddress` method to the `CPU` class, implementing address calculation for all NES addressing modes, including IMMEDIATE, ZERO_PAGE, ABSOLUTE, RELATIVE, INDIRECT, INDIRECT_INDEXED, and INDEXED_INDIRECT. This includes handling 6502-specific quirks, such as the indirect jump bug and sign extension for relative addressing.
* Updated the `step` method to use the new `resolveAddress` function, ensuring consistent address resolution for instruction execution.

Constants and code clarity:

* Introduced new constants: `SIGNED_BYTE_MAX` and `BYTE_WRAP` to facilitate correct sign extension and byte wrapping in address calculations.