### PR TITLE
[CPU] Implement core instructions #22

### DIFF
--- a/src/main/java/dev/omatheusmesmo/selfmat/nes/emulator/core/cpu/CPU.java
+++ b/src/main/java/dev/omatheusmesmo/selfmat/nes/emulator/core/cpu/CPU.java
@@ -1,45 +1,49 @@
 package dev.omatheusmesmo.selfmat.nes.emulator.core.cpu;
 
-
 import dev.omatheusmesmo.selfmat.nes.emulator.core.cpu.opcode.AddressingMode;
 import dev.omatheusmesmo.selfmat.nes.emulator.core.cpu.opcode.InstructionMetadata;
 import dev.omatheusmesmo.selfmat.nes.emulator.core.cpu.opcode.Opcodes;
 import dev.omatheusmesmo.selfmat.nes.emulator.core.memory.Bus;
 
+import static dev.omatheusmesmo.selfmat.nes.emulator.core.cpu.CpuConstants.*;
+
+/**
+ * Represents the 6502 Central Processing Unit (CPU) of the NES.
+ * This class handles CPU state, fetches and executes instructions,
+ * and manages interaction with the system bus.
+ */
 public class CPU {
 
     private final Bus bus;
+    private final CpuInstructionSet instructionSet;
 
-    private int accumulator;
-    private int indexX;
-    private int indexY;
-    private int programCounter;
-    private int stackPointer;
-    private int statusRegister;
+    // --- Registers ---
+    /** Accumulator register (8-bit). */
+    int accumulator; 
+    /** X index register (8-bit). */
+    int indexX;      
+    /** Y index register (8-bit). */
+    int indexY;      
+    /** Program Counter (16-bit). Points to the next instruction to be fetched. */
+    int programCounter;
+    /** Stack Pointer (8-bit). Points to the next free location on the stack (page 0x01). */
+    int stackPointer;
+    /** Processor Status register (8-bit). Contains various flags. */
+    int statusRegister;
+
     private int cyclesRemaining;
 
-    public static final int CARRY_FLAG          = (1 << 0);
-    public static final int ZERO_FLAG           = (1 << 1);
-    public static final int INTERRUPT_DISABLE   = (1 << 2);
-    public static final int DECIMAL_MODE        = (1 << 3);
-    public static final int BREAK_COMMAND       = (1 << 4);
-    public static final int UNUSED_FLAG         = (1 << 5);
-    public static final int OVERFLOW_FLAG       = (1 << 6);
-    public static final int NEGATIVE_FLAG       = (1 << 7);
-    public static final int RESET_VECTOR_LOW = 0xFFFC;
-    public static final int RESET_VECTOR_HIGH = RESET_VECTOR_LOW + 1;
-    public static final int INITIAL_STACK_POINTER = 0xFD;
-    public static final int BYTE_MASK = 0xFF;
-    public static final int BITS_PER_BYTE = 8;
-    public static final int INITIAL_VALUE = 0;
-    public static final int MAX_ADDRESS_VALUE = 0xFFFF;
-    public static final int SIGNED_BYTE_MAX = 0x7F;
-    public static final int BYTE_WRAP = 0x100;
-
+    /**
+     * Constructs a new CPU instance.
+     * @param bus The system bus that the CPU interacts with for memory access.
+     */
     public CPU(Bus bus) {
         this.bus = bus;
+        this.instructionSet = new CpuInstructionSet(this); // Inject this CPU instance into its instruction set
         reset();
     }
+
+    // --- Control Methods ---
 
     /**
      * Resets the CPU to its initial state.
@@ -58,23 +62,10 @@ public class CPU {
         programCounter = (hi << BITS_PER_BYTE) | lo;
     }
 
-    private byte read(int address) {
-        return bus.read(address);
-    }
-
-    private void write(int address, byte data) {
-        bus.write(address, data);
-    }
-
-    private void setFlag(int flag, boolean value) {
-        if (value) statusRegister |= flag;
-        else statusRegister &= ~flag;
-    }
-
-    private boolean isFlagSet(int flag) {
-        return (statusRegister & flag) != INITIAL_VALUE;
-    }
-
+    /**
+     * Simulates one clock cycle of the CPU.
+     * Fetches and executes a new instruction if no cycles are remaining from the previous one.
+     */
     public void clock() {
         if (cyclesRemaining == INITIAL_VALUE) {
             cyclesRemaining = step();
@@ -82,25 +73,128 @@ public class CPU {
         cyclesRemaining--;
     }
 
+    /**
+     * Executes a single 6502 instruction.
+     * This involves fetching the opcode, decoding it, resolving the operand address,
+     * and dispatching to the appropriate instruction execution logic.
+     * @return The number of CPU cycles consumed by the executed instruction.
+     * @throws IllegalStateException if an unknown or unimplemented opcode is encountered.
+     */
     public int step() {
         int opcode = fetch() & BYTE_MASK;
         InstructionMetadata metadata = Opcodes.getInstructionMetadata(opcode);
 
         if (metadata.addressingMode() == AddressingMode.UNKNOWN) {
-            throw new IllegalStateException(String.format("Unknown opcode: 0x%02X at PC: 0x%04X", opcode, programCounter - 1));
+            throw new IllegalStateException(String.format("Unknown opcode: 0x%02X at PC: 0x%04X", opcode, (programCounter - 1) & MAX_ADDRESS_VALUE));
         }
 
-        int address = resolveAddress(metadata.addressingMode());
+        int operandAddress = resolveAddress(metadata.addressingMode());
+        instructionSet.execute(metadata, operandAddress); // Delegates execution to CpuInstructionSet which has the dispatcher
 
         return metadata.cycles();
     }
 
-    public byte fetch() {
+    // --- Helper Methods for Memory and Flags (Package-Private for CpuInstructionSet) ---
+
+    /**
+     * Reads a byte from the system bus at the specified 16-bit address.
+     * @param address The 16-bit memory address to read from.
+     * @return The byte read from memory.
+     */
+    byte read(int address) { 
+        return bus.read(address);
+    }
+
+    /**
+     * Writes a byte to the system bus at the specified 16-bit address.
+     * @param address The 16-bit memory address to write to.
+     * @param data The byte data to write.
+     */
+    void write(int address, byte data) { 
+        bus.write(address, data);
+    }
+
+    /**
+     * Sets or clears a specific flag in the Processor Status register.
+     * @param flag The flag bit to modify (e.g., CARRY_FLAG, ZERO_FLAG).
+     * @param value True to set the flag, false to clear it.
+     */
+    void setFlag(int flag, boolean value) { 
+        if (value) statusRegister |= flag;
+        else statusRegister &= ~flag;
+    }
+
+    /**
+     * Checks if a specific flag in the Processor Status register is set.
+     * @param flag The flag bit to check.
+     * @return True if the flag is set, false otherwise.
+     */
+    boolean isFlagSet(int flag) { 
+        return (statusRegister & flag) != INITIAL_VALUE;
+    }
+
+    /**
+     * Fetches the byte at the current Program Counter (PC) and increments the PC.
+     * @return The byte fetched from memory.
+     */
+    byte fetch() {
         byte data = read(programCounter);
-        programCounter= (programCounter + 1) & MAX_ADDRESS_VALUE; // Wrap around 16-bit address space
+        programCounter = (programCounter + 1) & MAX_ADDRESS_VALUE;
         return data;
     }
 
+    /**
+     * Pushes a byte onto the CPU stack.
+     * Decrements the stack pointer after writing the data.
+     * The stack is located on memory page 0x01 ($0100 - $01FF).
+     * @param data The byte to push onto the stack.
+     */
+    void push(byte data) { // Package-private for CpuInstructionSet
+        write(0x0100 + stackPointer, data);
+        stackPointer = (stackPointer - 1) & BYTE_MASK;
+    }
+
+    /**
+     * Pushes a 16-bit address onto the CPU stack.
+     * Pushes high byte then low byte.
+     * @param address The 16-bit address to push.
+     */
+    void pushAddress(int address) { // Package-private for CpuInstructionSet
+        push((byte) ((address >> BITS_PER_BYTE) & BYTE_MASK)); // Push high byte
+        push((byte) (address & BYTE_MASK)); // Push low byte
+    }
+
+    /**
+     * Pops a byte from the CPU stack.
+     * Increments the stack pointer before reading the data.
+     * The stack is located on memory page 0x01 ($0100 - $01FF).
+     * @return The byte popped from the stack.
+     */
+    byte pop() { // Package-private for CpuInstructionSet
+        stackPointer = (stackPointer + 1) & BYTE_MASK;
+        return read(0x0100 + stackPointer);
+    }
+
+    /**
+     * Pops a 16-bit address from the CPU stack.
+     * Pops low byte then high byte.
+     * @return The 16-bit address popped from the stack.
+     */
+    int popAddress() { // Package-private for CpuInstructionSet
+        int lo = pop() & BYTE_MASK; // Pop low byte
+        int hi = pop() & BYTE_MASK; // Pop high byte
+        return (hi << BITS_PER_BYTE) | lo;
+    }
+
+    // --- Addressing Modes Resolution ---
+
+    /**
+     * Resolves the effective memory address for the current instruction's operand
+     * based on the specified addressing mode. This method also advances the
+     * Program Counter as necessary for multi-byte operands.
+     * @param addressingMode The addressing mode to use.
+     * @return The resolved 16-bit effective memory address of the operand.
+     */
     private int resolveAddress(AddressingMode addressingMode) {
         return switch (addressingMode) {
             case IMMEDIATE -> {
@@ -129,26 +223,27 @@ public class CPU {
                 int hi = fetch() & BYTE_MASK;
                 yield (((hi << BITS_PER_BYTE) | lo) + indexX) & MAX_ADDRESS_VALUE;
             }
-            case  ABSOLUTE_Y -> {
+            case ABSOLUTE_Y -> {
                 int lo = fetch() & BYTE_MASK;
                 int hi = fetch() & BYTE_MASK;
                 yield (((hi << BITS_PER_BYTE) | lo) + indexY) & MAX_ADDRESS_VALUE;
             }
             case RELATIVE -> {
                 int offset = fetch() & BYTE_MASK;
-                if (offset > SIGNED_BYTE_MAX) offset -= BYTE_WRAP; // sign-extend 8-bit offset
+                if (offset > SIGNED_BYTE_MAX) offset -= BYTE_WRAP;
                 yield (programCounter + offset) & MAX_ADDRESS_VALUE;
             }
             case INDIRECT -> {
                 int pointerLo = fetch() & BYTE_MASK;
                 int pointerHi = fetch() & BYTE_MASK;
                 int pointer = (pointerHi << BITS_PER_BYTE) | pointerLo;
-                // 6502 bug: if the low byte of the pointer is 0xFF, it wraps around to the start of the page
                 int effectiveLo = read(pointer) & BYTE_MASK;
-                int effectiveHi = read((pointer & BYTE_MASK) | ((pointer + 1) & BYTE_MASK)) & BYTE_MASK;
+                // Emulates 6502 JMP Indirect Page Boundary Bug:
+                // if the low byte of the pointer is 0xFF, the high byte is fetched from the start of the current page.
+                int effectiveHi = read((pointer & 0xFF00) | ((pointer + 1) & BYTE_MASK)) & BYTE_MASK;
                 yield (effectiveHi << BITS_PER_BYTE) | effectiveLo;
             }
-            case  INDIRECT_INDEXED -> {
+            case INDIRECT_INDEXED -> {
                 int pointer = fetch() & BYTE_MASK;
                 int baseLo = read(pointer) & BYTE_MASK;
                 int baseHi = read(pointer + 1) & BYTE_MASK;
@@ -161,12 +256,8 @@ public class CPU {
                 int effectiveHi = read(pointer + 1) & BYTE_MASK;
                 yield (effectiveHi << BITS_PER_BYTE) | effectiveLo;
             }
-            // IMPLIED, ACCUMULATOR etc. would be handled in instruction execution logic
+            // IMPLIED, ACCUMULATOR modes are handled by the instruction logic and do not require an operand address.
             default -> INITIAL_VALUE;
         };
-
-
     }
-
-
 }

--- a/src/main/java/dev/omatheusmesmo/selfmat/nes/emulator/core/cpu/CpuConstants.java
+++ b/src/main/java/dev/omatheusmesmo/selfmat/nes/emulator/core/cpu/CpuConstants.java
@@ -1,0 +1,55 @@
+package dev.omatheusmesmo.selfmat.nes.emulator.core.cpu;
+
+/**
+ * Utility class holding various constants for the 6502 CPU emulation.
+ * These constants define flag bits, memory addresses, and bitwise masks.
+ */
+public final class CpuConstants {
+
+    /**
+     * Private constructor to prevent instantiation of this utility class.
+     */
+    private CpuConstants() {
+        // Utility class
+    }
+
+    // --- Processor Status (P) Register Flags ---
+    /** Carry Flag (C) - Bit 0 */
+    public static final int CARRY_FLAG          = (1 << 0);
+    /** Zero Flag (Z) - Bit 1 */
+    public static final int ZERO_FLAG           = (1 << 1);
+    /** Interrupt Disable Flag (I) - Bit 2 */
+    public static final int INTERRUPT_DISABLE   = (1 << 2);
+    /** Decimal Mode Flag (D) - Bit 3 */
+    public static final int DECIMAL_MODE        = (1 << 3);
+    /** Break Command Flag (B) - Bit 4 */
+    public static final int BREAK_COMMAND       = (1 << 4);
+    /** Unused Flag (U) - Bit 5 (Always set to 1) */
+    public static final int UNUSED_FLAG         = (1 << 5);
+    /** Overflow Flag (V) - Bit 6 */
+    public static final int OVERFLOW_FLAG       = (1 << 6);
+    /** Negative Flag (N) - Bit 7 */
+    public static final int NEGATIVE_FLAG       = (1 << 7);
+    
+    // --- Memory Addresses ---
+    /** Low byte address for the Reset Vector (0xFFFC). */
+    public static final int RESET_VECTOR_LOW = 0xFFFC;
+    /** High byte address for the Reset Vector (0xFFFD). */
+    public static final int RESET_VECTOR_HIGH = 0xFFFD;
+    /** Initial value for the Stack Pointer on reset (0xFD). */
+    public static final int INITIAL_STACK_POINTER = 0xFD;
+
+    // --- General Bitwise and Value Constants ---
+    /** Mask for extracting the lowest 8 bits (to simulate unsigned byte). */
+    public static final int BYTE_MASK = 0xFF;
+    /** Number of bits in a byte. */
+    public static final int BITS_PER_BYTE = 8;
+    /** Common initial value for registers/flags (0). */
+    public static final int INITIAL_VALUE = 0;
+    /** Mask for 16-bit addresses (0xFFFF). */
+    public static final int MAX_ADDRESS_VALUE = 0xFFFF;
+    /** Maximum value for a signed 8-bit number (0x7F). */
+    public static final int SIGNED_BYTE_MAX = 0x7F;
+    /** Value used for 8-bit wrap-around calculations (0x100). */
+    public static final int BYTE_WRAP = 0x100;
+}

--- a/src/main/java/dev/omatheusmesmo/selfmat/nes/emulator/core/cpu/CpuInstructionSet.java
+++ b/src/main/java/dev/omatheusmesmo/selfmat/nes/emulator/core/cpu/CpuInstructionSet.java
@@ -1,0 +1,285 @@
+package dev.omatheusmesmo.selfmat.nes.emulator.core.cpu;
+
+import dev.omatheusmesmo.selfmat.nes.emulator.core.cpu.opcode.InstructionExecutor;
+import dev.omatheusmesmo.selfmat.nes.emulator.core.cpu.opcode.InstructionMetadata;
+import dev.omatheusmesmo.selfmat.nes.emulator.core.cpu.opcode.Opcodes; // Needed for InstructionMetadata to reference Opcodes.getInstructionMetadata
+import dev.omatheusmesmo.selfmat.nes.emulator.core.cpu.opcode.AddressingMode; // Needed for InstructionMetadata.addressingMode()
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static dev.omatheusmesmo.selfmat.nes.emulator.core.cpu.CpuConstants.*;
+
+/**
+ * Encapsulates the execution logic for 6502 CPU instructions.
+ * This class interacts directly with the CPU's state (registers, bus, flags)
+ * through a provided CPU instance. It also handles the dispatching of instructions
+ * based on their mnemonic.
+ */
+public class CpuInstructionSet {
+
+    private final CPU cpu; // Reference to the CPU instance
+    private final Map<String, InstructionExecutor> instructionExecutors = new HashMap<>();
+
+    /**
+     * Constructs a new CpuInstructionSet with a reference to the CPU instance.
+     * @param cpu The CPU instance this instruction set will operate on.
+     */
+    public CpuInstructionSet(CPU cpu) {
+        this.cpu = cpu;
+        setupInstructionExecutors(); // Initialize the instruction dispatch map
+    }
+
+    /**
+     * Updates the Zero (Z) and Negative (N) flags based on the given value.
+     * @param value The value to check.
+     */
+    public void updateNegativeAndZeroFlags(int value) {
+        cpu.setFlag(ZERO_FLAG, (value & BYTE_MASK) == INITIAL_VALUE);
+        cpu.setFlag(NEGATIVE_FLAG, (value & NEGATIVE_FLAG) != INITIAL_VALUE);
+    }
+
+    /**
+     * Updates the Carry (C), Zero (Z), Negative (N), and Overflow (V) flags
+     * for arithmetic operations like ADC and SBC.
+     */
+    private void updateArithmeticFlags(int result, int operand1, int operand2, boolean isSBC) {
+        // Carry Flag
+        if (isSBC) {
+            cpu.setFlag(CARRY_FLAG, (result >= 0)); // SBC: Carry set if no borrow (result >= 0)
+        } else {
+            cpu.setFlag(CARRY_FLAG, result > BYTE_MASK); // ADC: Carry set if overflow > 255
+        }
+
+        // Zero Flag
+        cpu.setFlag(ZERO_FLAG, (result & BYTE_MASK) == INITIAL_VALUE);
+
+        // Negative Flag
+        cpu.setFlag(NEGATIVE_FLAG, (result & NEGATIVE_FLAG) != INITIAL_VALUE);
+
+        // Overflow Flag
+        // Formula: (Operand1 ^ Result) & (Operand2 ^ Result) & 0x80
+        // ADC: Overflow if signs of operands are same, but result sign is different.
+        // SBC: Operand2 is effectively inverted.
+        int intermediate = (operand1 ^ result) & (operand2 ^ result);
+        if (isSBC) {
+            intermediate = (operand1 ^ result) & ((~operand2) ^ result);
+        }
+        cpu.setFlag(OVERFLOW_FLAG, (intermediate & NEGATIVE_FLAG) != INITIAL_VALUE);
+    }
+
+    // --- Load and Store ---
+
+    public void lda(int operandAddress) {
+        cpu.accumulator = cpu.read(operandAddress) & BYTE_MASK;
+        updateNegativeAndZeroFlags(cpu.accumulator);
+    }
+
+    public void ldx(int operandAddress) {
+        cpu.indexX = cpu.read(operandAddress) & BYTE_MASK;
+        updateNegativeAndZeroFlags(cpu.indexX);
+    }
+
+    public void ldy(int operandAddress) {
+        cpu.indexY = cpu.read(operandAddress) & BYTE_MASK;
+        updateNegativeAndZeroFlags(cpu.indexY);
+    }
+
+    public void sta(int operandAddress) {
+        cpu.write(operandAddress, (byte) (cpu.accumulator & BYTE_MASK));
+    }
+
+    public void stx(int operandAddress) {
+        cpu.write(operandAddress, (byte) (cpu.indexX & BYTE_MASK));
+    }
+
+    public void sty(int operandAddress) {
+        cpu.write(operandAddress, (byte) (cpu.indexY & BYTE_MASK));
+    }
+
+    // --- Increment and Decrement ---
+
+    public void inx(int operandAddress) {
+        cpu.indexX = (cpu.indexX + 1) & BYTE_MASK;
+        updateNegativeAndZeroFlags(cpu.indexX);
+    }
+
+    public void dex(int operandAddress) {
+        cpu.indexX = (cpu.indexX - 1) & BYTE_MASK;
+        updateNegativeAndZeroFlags(cpu.indexX);
+    }
+
+    public void iny(int operandAddress) {
+        cpu.indexY = (cpu.indexY + 1) & BYTE_MASK;
+        updateNegativeAndZeroFlags(cpu.indexY);
+    }
+
+    public void dey(int operandAddress) {
+        cpu.indexY = (cpu.indexY - 1) & BYTE_MASK;
+        updateNegativeAndZeroFlags(cpu.indexY);
+    }
+
+    public void inc(int operandAddress) {
+        int value = (cpu.read(operandAddress) + 1) & BYTE_MASK;
+        cpu.write(operandAddress, (byte) value);
+        updateNegativeAndZeroFlags(value);
+    }
+
+    public void dec(int operandAddress) {
+        int value = (cpu.read(operandAddress) - 1) & BYTE_MASK;
+        cpu.write(operandAddress, (byte) value);
+        updateNegativeAndZeroFlags(value);
+    }
+
+    // --- Branches and Jumps ---
+
+    public void jmp(int operandAddress) {
+        cpu.programCounter = operandAddress;
+    }
+
+    public void jsr(int operandAddress) {
+        // Push PC-1 (High then Low)
+        int returnAddr = cpu.programCounter - 1;
+        cpu.pushAddress(returnAddr); 
+        cpu.programCounter = operandAddress;
+    }
+
+    public void rts(int operandAddress) {
+        int returnAddr = cpu.popAddress();
+        cpu.programCounter = returnAddr + 1;
+    }
+
+    public void brk(int operandAddress) {
+        // Push PC+1 (High then Low)
+        // BRK is a 2-byte instruction (usually padding byte after opcode), PC has already advanced by 1 in fetch
+        cpu.pushAddress(cpu.programCounter); 
+        
+        // Push Status with Break (B) flag set
+        cpu.push((byte) (cpu.statusRegister | BREAK_COMMAND | UNUSED_FLAG));
+        
+        cpu.setFlag(INTERRUPT_DISABLE, true);
+        
+        // Load Interrupt Vector (0xFFFE/F)
+        int lo = cpu.read(0xFFFE) & BYTE_MASK;
+        int hi = cpu.read(0xFFFF) & BYTE_MASK;
+        cpu.programCounter = (hi << BITS_PER_BYTE) | lo;
+    }
+
+    // --- Arithmetic and Logic ---
+
+    public void adc(int operandAddress) {
+        int fetched = cpu.read(operandAddress) & BYTE_MASK;
+        int sum = cpu.accumulator + fetched + (cpu.isFlagSet(CARRY_FLAG) ? 1 : 0);
+        
+        updateArithmeticFlags(sum, cpu.accumulator, fetched, false);
+        cpu.accumulator = sum & BYTE_MASK;
+    }
+
+    public void sbc(int operandAddress) {
+        int fetched = cpu.read(operandAddress) & BYTE_MASK;
+        // SBC is A - M - (1 - C) -> A + (-M - 1) + C -> A + ~M + C
+        int inverted = fetched ^ BYTE_MASK;
+        int sum = cpu.accumulator + inverted + (cpu.isFlagSet(CARRY_FLAG) ? 1 : 0);
+        
+        updateArithmeticFlags(sum, cpu.accumulator, fetched, true);
+        cpu.accumulator = sum & BYTE_MASK;
+    }
+
+    public void and(int operandAddress) {
+        cpu.accumulator &= cpu.read(operandAddress) & BYTE_MASK;
+        updateNegativeAndZeroFlags(cpu.accumulator);
+    }
+
+    public void ora(int operandAddress) {
+        cpu.accumulator |= cpu.read(operandAddress) & BYTE_MASK;
+        updateNegativeAndZeroFlags(cpu.accumulator);
+    }
+
+    public void eor(int operandAddress) {
+        cpu.accumulator ^= cpu.read(operandAddress) & BYTE_MASK;
+        updateNegativeAndZeroFlags(cpu.accumulator);
+    }
+
+    // --- Stack Operations ---
+
+    public void pha(int operandAddress) {
+        cpu.push((byte) cpu.accumulator);
+    }
+
+    public void pla(int operandAddress) {
+        cpu.accumulator = cpu.pop() & BYTE_MASK;
+        updateNegativeAndZeroFlags(cpu.accumulator);
+    }
+
+    public void php(int operandAddress) {
+        // PHP always pushes with Break (B) and Unused (U) flags set
+        cpu.push((byte) (cpu.statusRegister | BREAK_COMMAND | UNUSED_FLAG));
+    }
+
+    public void plp(int operandAddress) {
+        // Pull into status, but ignore Unused (U) and Break (B) bits from stack
+        // U is always 1, B usually ignored/cleared in register
+        int pulled = cpu.pop() & BYTE_MASK;
+        cpu.statusRegister = pulled;
+        cpu.setFlag(UNUSED_FLAG, true);
+        cpu.setFlag(BREAK_COMMAND, false); // B flag does not physically exist in the register
+    }
+
+    // --- Dispatching Logic ---
+
+    /**
+     * Sets up the map of instruction mnemonics to their respective execution logic.
+     * This method is called once during the construction of CpuInstructionSet.
+     */
+    private void setupInstructionExecutors() {
+        // Load and Store
+        instructionExecutors.put("LDA", this::lda);
+        instructionExecutors.put("LDX", this::ldx);
+        instructionExecutors.put("LDY", this::ldy);
+        instructionExecutors.put("STA", this::sta);
+        instructionExecutors.put("STX", this::stx);
+        instructionExecutors.put("STY", this::sty);
+
+        // Increment/Decrement
+        instructionExecutors.put("INX", this::inx);
+        instructionExecutors.put("DEX", this::dex);
+        instructionExecutors.put("INY", this::iny);
+        instructionExecutors.put("DEY", this::dey);
+        instructionExecutors.put("INC", this::inc);
+        instructionExecutors.put("DEC", this::dec);
+
+        // Branches and Jumps
+        instructionExecutors.put("JMP", this::jmp);
+        instructionExecutors.put("JSR", this::jsr);
+        instructionExecutors.put("RTS", this::rts);
+        instructionExecutors.put("BRK", this::brk);
+
+        // Arithmetic and Logic
+        instructionExecutors.put("ADC", this::adc);
+        instructionExecutors.put("SBC", this::sbc);
+        instructionExecutors.put("AND", this::and);
+        instructionExecutors.put("ORA", this::ora);
+        instructionExecutors.put("EOR", this::eor);
+
+        // Stack Operations
+        instructionExecutors.put("PHA", this::pha);
+        instructionExecutors.put("PLA", this::pla);
+        instructionExecutors.put("PHP", this::php);
+        instructionExecutors.put("PLP", this::plp);
+    }
+
+    /**
+     * Executes the instruction defined by the metadata.
+     * Dispatches the call to the appropriate instruction implementation based on the mnemonic.
+     * @param metadata The InstructionMetadata containing the mnemonic.
+     * @param operandAddress The resolved memory address for the operand.
+     * @throws IllegalStateException if an executor for the mnemonic is not found.
+     */
+    public void execute(InstructionMetadata metadata, int operandAddress) {
+        InstructionExecutor executor = instructionExecutors.get(metadata.mnemonic());
+        if (executor == null) {
+            throw new IllegalStateException("Executor not found for instruction: " + metadata.mnemonic() + " (Opcode: " + metadata.cycles() + ")");
+        }
+        executor.execute(operandAddress);
+    }
+}

--- a/src/main/java/dev/omatheusmesmo/selfmat/nes/emulator/core/cpu/opcode/InstructionExecutor.java
+++ b/src/main/java/dev/omatheusmesmo/selfmat/nes/emulator/core/cpu/opcode/InstructionExecutor.java
@@ -1,0 +1,7 @@
+package dev.omatheusmesmo.selfmat.nes.emulator.core.cpu.opcode;
+
+@FunctionalInterface
+public interface InstructionExecutor {
+
+    void execute(int operandAddress);
+}


### PR DESCRIPTION
Fix #22 

# Summary (Copilot)

This pull request refactors and modularizes the NES 6502 CPU emulation code, improving maintainability and code clarity. The main changes include extracting CPU constants into a dedicated class, introducing a new `CpuInstructionSet` class to encapsulate instruction execution and dispatch, and enhancing documentation throughout the codebase. The CPU core is now cleaner, with responsibilities better separated between instruction logic and CPU state management.

**Key changes:**

### CPU Architecture Refactoring

* Extracted all 6502 CPU-related constants (such as flag bits and memory addresses) from `CPU.java` into a new utility class `CpuConstants`, reducing duplication and improving readability.
* Introduced a new `CpuInstructionSet` class responsible for all instruction execution logic, including arithmetic, load/store, stack, and control flow operations. This class receives a reference to the CPU instance to manipulate its state directly.
* Moved instruction dispatching out of the main CPU class: `CpuInstructionSet` now maintains a mapping from instruction mnemonics to their implementations, and the CPU delegates instruction execution to this class.

### Code Structure and Documentation

* Added extensive Javadoc comments and inline documentation to the CPU, constants, and instruction set classes, clarifying the purpose and mechanics of each method and field. [[1]](diffhunk://#diff-5cc8c2c04c4805ec0d124aba4287809314271a83af5fc1869425179805190c82L3-R47) [[2]](diffhunk://#diff-ad506968d280a1e80b36be2ded4b149b937426f78153780a9e2bf2b0f7ce50daR1-R55) [[3]](diffhunk://#diff-4126581eb998e77ba8eed4be8fbe878262d57c605194218117c4724b771bce77R1-R285)
* Improved encapsulation and code clarity in `CPU.java` by grouping methods by theme (control, memory/flags, stack, addressing modes) and making helper methods package-private for use by `CpuInstructionSet`. [[1]](diffhunk://#diff-5cc8c2c04c4805ec0d124aba4287809314271a83af5fc1869425179805190c82L3-R47) [[2]](diffhunk://#diff-5cc8c2c04c4805ec0d124aba4287809314271a83af5fc1869425179805190c82L59-R261)

### Instruction Execution and Dispatch

* Added a new functional interface `InstructionExecutor` to standardize instruction execution signatures, enabling clean mapping and invocation of instruction logic.
* Implemented detailed logic for a wide range of 6502 instructions (LDA, STA, ADC, SBC, stack ops, etc.) in `CpuInstructionSet`, including correct flag handling and stack operations.

### Addressing Modes and Operand Handling

* Refactored the operand address resolution logic in the CPU to use a `switch` statement, handling all 6502 addressing modes and emulating hardware quirks (such as the JMP indirect page boundary bug).

These changes collectively modernize the CPU emulation code, making it easier to extend and maintain while improving correctness and documentation.