### PR TITLE
[CPU] Handle Processor Flags #23

### DIFF
--- a/src/main/java/dev/omatheusmesmo/selfmat/nes/emulator/core/cpu/CPU.java
+++ b/src/main/java/dev/omatheusmesmo/selfmat/nes/emulator/core/cpu/CPU.java
@@ -256,7 +256,8 @@ public class CPU {
                 int effectiveHi = read(pointer + 1) & BYTE_MASK;
                 yield (effectiveHi << BITS_PER_BYTE) | effectiveLo;
             }
-            // IMPLIED, ACCUMULATOR modes are handled by the instruction logic and do not require an operand address.
+            case ACCUMULATOR -> ACCUMULATOR_SENTINEL;
+            // IMPLIED mode is handled by the instruction logic and does not require an operand address.
             default -> INITIAL_VALUE;
         };
     }

--- a/src/main/java/dev/omatheusmesmo/selfmat/nes/emulator/core/cpu/CPU.java
+++ b/src/main/java/dev/omatheusmesmo/selfmat/nes/emulator/core/cpu/CPU.java
@@ -150,7 +150,7 @@ public class CPU {
      * @param data The byte to push onto the stack.
      */
     void push(byte data) { // Package-private for CpuInstructionSet
-        write(0x0100 + stackPointer, data);
+        write(STACK_PAGE_START + stackPointer, data);
         stackPointer = (stackPointer - 1) & BYTE_MASK;
     }
 
@@ -172,7 +172,7 @@ public class CPU {
      */
     byte pop() { // Package-private for CpuInstructionSet
         stackPointer = (stackPointer + 1) & BYTE_MASK;
-        return read(0x0100 + stackPointer);
+        return read(STACK_PAGE_START + stackPointer);
     }
 
     /**

--- a/src/main/java/dev/omatheusmesmo/selfmat/nes/emulator/core/cpu/CpuConstants.java
+++ b/src/main/java/dev/omatheusmesmo/selfmat/nes/emulator/core/cpu/CpuConstants.java
@@ -36,8 +36,14 @@ public final class CpuConstants {
     public static final int RESET_VECTOR_LOW = 0xFFFC;
     /** High byte address for the Reset Vector (0xFFFD). */
     public static final int RESET_VECTOR_HIGH = 0xFFFD;
+    /** Low byte address for the Interrupt/BRK Vector (0xFFFE). */
+    public static final int INTERRUPT_VECTOR_LOW = 0xFFFE;
+    /** High byte address for the Interrupt/BRK Vector (0xFFFF). */
+    public static final int INTERRUPT_VECTOR_HIGH = 0xFFFF;
     /** Initial value for the Stack Pointer on reset (0xFD). */
     public static final int INITIAL_STACK_POINTER = 0xFD;
+    /** Memory address where the stack page starts (Page 1). */
+    public static final int STACK_PAGE_START = 0x0100;
 
     // --- General Bitwise and Value Constants ---
     /** Mask for extracting the lowest 8 bits (to simulate unsigned byte). */

--- a/src/main/java/dev/omatheusmesmo/selfmat/nes/emulator/core/cpu/CpuConstants.java
+++ b/src/main/java/dev/omatheusmesmo/selfmat/nes/emulator/core/cpu/CpuConstants.java
@@ -52,4 +52,6 @@ public final class CpuConstants {
     public static final int SIGNED_BYTE_MAX = 0x7F;
     /** Value used for 8-bit wrap-around calculations (0x100). */
     public static final int BYTE_WRAP = 0x100;
+    /** Sentinel value used to indicate that an instruction should operate on the Accumulator. */
+    public static final int ACCUMULATOR_SENTINEL = -1;
 }

--- a/src/main/java/dev/omatheusmesmo/selfmat/nes/emulator/core/cpu/CpuInstructionSet.java
+++ b/src/main/java/dev/omatheusmesmo/selfmat/nes/emulator/core/cpu/CpuInstructionSet.java
@@ -160,8 +160,8 @@ public class CpuInstructionSet {
         cpu.setFlag(INTERRUPT_DISABLE, true);
         
         // Load Interrupt Vector (0xFFFE/F)
-        int lo = cpu.read(0xFFFE) & BYTE_MASK;
-        int hi = cpu.read(0xFFFF) & BYTE_MASK;
+        int lo = cpu.read(INTERRUPT_VECTOR_LOW) & BYTE_MASK;
+        int hi = cpu.read(INTERRUPT_VECTOR_HIGH) & BYTE_MASK;
         cpu.programCounter = (hi << BITS_PER_BYTE) | lo;
     }
 
@@ -313,19 +313,19 @@ public class CpuInstructionSet {
 
     public void bit(int operandAddress) {
         int value = cpu.read(operandAddress) & BYTE_MASK;
-        cpu.setFlag(NEGATIVE_FLAG, (value & 0x80) != INITIAL_VALUE);
-        cpu.setFlag(OVERFLOW_FLAG, (value & 0x40) != INITIAL_VALUE); // V flag is bit 6 of the operand
+        cpu.setFlag(NEGATIVE_FLAG, (value & NEGATIVE_FLAG) != INITIAL_VALUE);
+        cpu.setFlag(OVERFLOW_FLAG, (value & OVERFLOW_FLAG) != INITIAL_VALUE); // V flag is bit 6 of the operand
         cpu.setFlag(ZERO_FLAG, (cpu.accumulator & value) == INITIAL_VALUE);
     }
 
     public void asl(int operandAddress) {
         if (operandAddress == ACCUMULATOR_SENTINEL) {
-            cpu.setFlag(CARRY_FLAG, (cpu.accumulator & 0x80) != INITIAL_VALUE);
+            cpu.setFlag(CARRY_FLAG, (cpu.accumulator & NEGATIVE_FLAG) != INITIAL_VALUE);
             cpu.accumulator = (cpu.accumulator << 1) & BYTE_MASK;
             updateNegativeAndZeroFlags(cpu.accumulator);
         } else {
             int value = cpu.read(operandAddress) & BYTE_MASK;
-            cpu.setFlag(CARRY_FLAG, (value & 0x80) != INITIAL_VALUE);
+            cpu.setFlag(CARRY_FLAG, (value & NEGATIVE_FLAG) != INITIAL_VALUE);
             value = (value << 1) & BYTE_MASK;
             cpu.write(operandAddress, (byte) value);
             updateNegativeAndZeroFlags(value);
@@ -334,12 +334,12 @@ public class CpuInstructionSet {
 
     public void lsr(int operandAddress) {
         if (operandAddress == ACCUMULATOR_SENTINEL) {
-            cpu.setFlag(CARRY_FLAG, (cpu.accumulator & 0x01) != INITIAL_VALUE);
+            cpu.setFlag(CARRY_FLAG, (cpu.accumulator & CARRY_FLAG) != INITIAL_VALUE);
             cpu.accumulator = (cpu.accumulator >> 1) & BYTE_MASK;
             updateNegativeAndZeroFlags(cpu.accumulator);
         } else {
             int value = cpu.read(operandAddress) & BYTE_MASK;
-            cpu.setFlag(CARRY_FLAG, (value & 0x01) != INITIAL_VALUE);
+            cpu.setFlag(CARRY_FLAG, (value & CARRY_FLAG) != INITIAL_VALUE);
             value = (value >> 1) & BYTE_MASK;
             cpu.write(operandAddress, (byte) value);
             updateNegativeAndZeroFlags(value);
@@ -349,12 +349,12 @@ public class CpuInstructionSet {
     public void rol(int operandAddress) {
         boolean oldCarry = cpu.isFlagSet(CARRY_FLAG);
         if (operandAddress == ACCUMULATOR_SENTINEL) {
-            cpu.setFlag(CARRY_FLAG, (cpu.accumulator & 0x80) != INITIAL_VALUE);
+            cpu.setFlag(CARRY_FLAG, (cpu.accumulator & NEGATIVE_FLAG) != INITIAL_VALUE);
             cpu.accumulator = ((cpu.accumulator << 1) | (oldCarry ? 1 : 0)) & BYTE_MASK;
             updateNegativeAndZeroFlags(cpu.accumulator);
         } else {
             int value = cpu.read(operandAddress) & BYTE_MASK;
-            cpu.setFlag(CARRY_FLAG, (value & 0x80) != INITIAL_VALUE);
+            cpu.setFlag(CARRY_FLAG, (value & NEGATIVE_FLAG) != INITIAL_VALUE);
             value = ((value << 1) | (oldCarry ? 1 : 0)) & BYTE_MASK;
             cpu.write(operandAddress, (byte) value);
             updateNegativeAndZeroFlags(value);
@@ -364,13 +364,13 @@ public class CpuInstructionSet {
     public void ror(int operandAddress) {
         boolean oldCarry = cpu.isFlagSet(CARRY_FLAG);
         if (operandAddress == ACCUMULATOR_SENTINEL) {
-            cpu.setFlag(CARRY_FLAG, (cpu.accumulator & 0x01) != INITIAL_VALUE);
-            cpu.accumulator = ((cpu.accumulator >> 1) | (oldCarry ? 0x80 : 0)) & BYTE_MASK;
+            cpu.setFlag(CARRY_FLAG, (cpu.accumulator & CARRY_FLAG) != INITIAL_VALUE);
+            cpu.accumulator = ((cpu.accumulator >> 1) | (oldCarry ? NEGATIVE_FLAG : 0)) & BYTE_MASK;
             updateNegativeAndZeroFlags(cpu.accumulator);
         } else {
             int value = cpu.read(operandAddress) & BYTE_MASK;
-            cpu.setFlag(CARRY_FLAG, (value & 0x01) != INITIAL_VALUE);
-            value = ((value >> 1) | (oldCarry ? 0x80 : 0)) & BYTE_MASK;
+            cpu.setFlag(CARRY_FLAG, (value & CARRY_FLAG) != INITIAL_VALUE);
+            value = ((value >> 1) | (oldCarry ? NEGATIVE_FLAG : 0)) & BYTE_MASK;
             cpu.write(operandAddress, (byte) value);
             updateNegativeAndZeroFlags(value);
         }

--- a/src/main/java/dev/omatheusmesmo/selfmat/nes/emulator/core/cpu/CpuInstructionSet.java
+++ b/src/main/java/dev/omatheusmesmo/selfmat/nes/emulator/core/cpu/CpuInstructionSet.java
@@ -225,6 +225,174 @@ public class CpuInstructionSet {
         cpu.setFlag(BREAK_COMMAND, false); // B flag does not physically exist in the register
     }
 
+    // Handle Processor Flags
+
+    public void clc(int operandAddress) {
+        cpu.setFlag(CARRY_FLAG, false);
+    }
+
+    public void sec(int operandAddress) {
+        cpu.setFlag(CARRY_FLAG, true);
+    }
+
+    public void cld(int operandAddress) {
+        cpu.setFlag(DECIMAL_MODE, false);
+    }
+
+    public void sed(int operandAddress) {
+        cpu.setFlag(DECIMAL_MODE, true);
+    }
+
+    public void cli(int operandAddress) {
+        cpu.setFlag(INTERRUPT_DISABLE, false);
+    }
+
+    public void sei(int operandAddress) {
+        cpu.setFlag(INTERRUPT_DISABLE, true);
+    }
+
+    public void clv(int operandAddress) {
+        cpu.setFlag(OVERFLOW_FLAG, false);
+    }
+
+    public void cmp(int operandAddress) {
+        int fetched = cpu.read(operandAddress) & BYTE_MASK;
+        int result = cpu.accumulator - fetched;
+
+        // Set flags based on the comparison
+        cpu.setFlag(CARRY_FLAG, cpu.accumulator >= fetched);
+        updateNegativeAndZeroFlags(result);
+    }
+
+    public void cpx(int operandAddress) {
+        int fetched = cpu.read(operandAddress) & BYTE_MASK;
+        int result = cpu.indexX - fetched;
+
+        // Set flags based on the comparison
+        cpu.setFlag(CARRY_FLAG, cpu.indexX >= fetched);
+        updateNegativeAndZeroFlags(result);
+    }
+
+    public void cpy(int operandAddress) {
+        int fetched = cpu.read(operandAddress) & BYTE_MASK;
+        int result = cpu.indexY - fetched;
+
+        // Set flags based on the comparison
+        cpu.setFlag(CARRY_FLAG, cpu.indexY >= fetched);
+        updateNegativeAndZeroFlags(result);
+    }
+
+    public void tax(int operandAddress) {
+        cpu.indexX = cpu.accumulator;
+        updateNegativeAndZeroFlags(cpu.indexX);
+    }
+
+    public void tay(int operandAddress) {
+        cpu.indexY = cpu.accumulator;
+        updateNegativeAndZeroFlags(cpu.indexY);
+    }
+
+    public void tsx(int operandAddress) {
+        cpu.indexX = cpu.stackPointer;
+        updateNegativeAndZeroFlags(cpu.indexX);
+    }
+
+    public void txa(int operandAddress) {
+        cpu.accumulator = cpu.indexX;
+        updateNegativeAndZeroFlags(cpu.accumulator);
+    }
+
+    public void tya(int operandAddress) {
+        cpu.accumulator = cpu.indexY;
+        updateNegativeAndZeroFlags(cpu.accumulator);
+    }
+
+    public void txs(int operandAddress) {
+        cpu.stackPointer = cpu.indexX;
+    }
+
+    public void bit(int operandAddress) {
+        int value = cpu.read(operandAddress) & BYTE_MASK;
+        cpu.setFlag(NEGATIVE_FLAG, (value & 0x80) != INITIAL_VALUE);
+        cpu.setFlag(OVERFLOW_FLAG, (value & 0x40) != INITIAL_VALUE); // V flag is bit 6 of the operand
+        cpu.setFlag(ZERO_FLAG, (cpu.accumulator & value) == INITIAL_VALUE);
+    }
+
+    public void asl(int operandAddress) {
+        if (operandAddress == ACCUMULATOR_SENTINEL) {
+            cpu.setFlag(CARRY_FLAG, (cpu.accumulator & 0x80) != INITIAL_VALUE);
+            cpu.accumulator = (cpu.accumulator << 1) & BYTE_MASK;
+            updateNegativeAndZeroFlags(cpu.accumulator);
+        } else {
+            int value = cpu.read(operandAddress) & BYTE_MASK;
+            cpu.setFlag(CARRY_FLAG, (value & 0x80) != INITIAL_VALUE);
+            value = (value << 1) & BYTE_MASK;
+            cpu.write(operandAddress, (byte) value);
+            updateNegativeAndZeroFlags(value);
+        }
+    }
+
+    public void lsr(int operandAddress) {
+        if (operandAddress == ACCUMULATOR_SENTINEL) {
+            cpu.setFlag(CARRY_FLAG, (cpu.accumulator & 0x01) != INITIAL_VALUE);
+            cpu.accumulator = (cpu.accumulator >> 1) & BYTE_MASK;
+            updateNegativeAndZeroFlags(cpu.accumulator);
+        } else {
+            int value = cpu.read(operandAddress) & BYTE_MASK;
+            cpu.setFlag(CARRY_FLAG, (value & 0x01) != INITIAL_VALUE);
+            value = (value >> 1) & BYTE_MASK;
+            cpu.write(operandAddress, (byte) value);
+            updateNegativeAndZeroFlags(value);
+        }
+    }
+
+    public void rol(int operandAddress) {
+        boolean oldCarry = cpu.isFlagSet(CARRY_FLAG);
+        if (operandAddress == ACCUMULATOR_SENTINEL) {
+            cpu.setFlag(CARRY_FLAG, (cpu.accumulator & 0x80) != INITIAL_VALUE);
+            cpu.accumulator = ((cpu.accumulator << 1) | (oldCarry ? 1 : 0)) & BYTE_MASK;
+            updateNegativeAndZeroFlags(cpu.accumulator);
+        } else {
+            int value = cpu.read(operandAddress) & BYTE_MASK;
+            cpu.setFlag(CARRY_FLAG, (value & 0x80) != INITIAL_VALUE);
+            value = ((value << 1) | (oldCarry ? 1 : 0)) & BYTE_MASK;
+            cpu.write(operandAddress, (byte) value);
+            updateNegativeAndZeroFlags(value);
+        }
+    }
+
+    public void ror(int operandAddress) {
+        boolean oldCarry = cpu.isFlagSet(CARRY_FLAG);
+        if (operandAddress == ACCUMULATOR_SENTINEL) {
+            cpu.setFlag(CARRY_FLAG, (cpu.accumulator & 0x01) != INITIAL_VALUE);
+            cpu.accumulator = ((cpu.accumulator >> 1) | (oldCarry ? 0x80 : 0)) & BYTE_MASK;
+            updateNegativeAndZeroFlags(cpu.accumulator);
+        } else {
+            int value = cpu.read(operandAddress) & BYTE_MASK;
+            cpu.setFlag(CARRY_FLAG, (value & 0x01) != INITIAL_VALUE);
+            value = ((value >> 1) | (oldCarry ? 0x80 : 0)) & BYTE_MASK;
+            cpu.write(operandAddress, (byte) value);
+            updateNegativeAndZeroFlags(value);
+        }
+    }
+
+    public void rti(int operandAddress) {
+        // Pull Status first (but ignore B and U bits)
+        int pulledStatus = cpu.pop() & BYTE_MASK;
+        cpu.statusRegister = pulledStatus;
+        cpu.setFlag(UNUSED_FLAG, true);
+        cpu.setFlag(BREAK_COMMAND, false); // B flag does not physically exist in the register
+
+        // Then pull PC (Low then High)
+        int lo = cpu.pop() & BYTE_MASK;
+        int hi = cpu.pop() & BYTE_MASK;
+        cpu.programCounter = (hi << BITS_PER_BYTE) | lo;
+    }
+
+    public void nop(int operandAddress) {
+        // No operation - do nothing
+    }
+
     // --- Dispatching Logic ---
 
     /**
@@ -266,6 +434,43 @@ public class CpuInstructionSet {
         instructionExecutors.put("PLA", this::pla);
         instructionExecutors.put("PHP", this::php);
         instructionExecutors.put("PLP", this::plp);
+
+        // Status Flag Changes
+        instructionExecutors.put("CLC", this::clc);
+        instructionExecutors.put("SEC", this::sec);
+        instructionExecutors.put("CLD", this::cld);
+        instructionExecutors.put("SED", this::sed);
+        instructionExecutors.put("CLI", this::cli);
+        instructionExecutors.put("SEI", this::sei);
+        instructionExecutors.put("CLV", this::clv);
+
+        // Comparisons
+        instructionExecutors.put("CMP", this::cmp);
+        instructionExecutors.put("CPX", this::cpx);
+        instructionExecutors.put("CPY", this::cpy);
+
+        // Register Transfers
+        instructionExecutors.put("TAX", this::tax);
+        instructionExecutors.put("TAY", this::tay);
+        instructionExecutors.put("TSX", this::tsx);
+        instructionExecutors.put("TXA", this::txa);
+        instructionExecutors.put("TYA", this::tya);
+        instructionExecutors.put("TXS", this::txs);
+
+        // Bit Test
+        instructionExecutors.put("BIT", this::bit);
+
+        // Shifts and Rotates
+        instructionExecutors.put("ASL", this::asl);
+        instructionExecutors.put("LSR", this::lsr);
+        instructionExecutors.put("ROL", this::rol);
+        instructionExecutors.put("ROR", this::ror);
+
+        // Return from Interrupt
+        instructionExecutors.put("RTI", this::rti);
+
+        // No Operation
+        instructionExecutors.put("NOP", this::nop);
     }
 
     /**


### PR DESCRIPTION
Fix #23 

# Summary (Copilot)

This pull request adds significant new functionality and refactors constants usage in the NES CPU emulator. The most important changes include implementing many core 6502 instructions, improving code maintainability by introducing named constants for special memory addresses and values, and updating instruction dispatch logic to support the new instructions.

**Instruction Implementation and Dispatch:**

* Implemented a wide range of 6502 instructions, including status flag operations (CLC, SEC, etc.), comparisons (CMP, CPX, CPY), register transfers (TAX, TAY, etc.), bit test (BIT), shifts and rotates (ASL, LSR, ROL, ROR), return from interrupt (RTI), and no operation (NOP), enhancing CPU emulation completeness.
* Updated the instruction executor map to include the new instructions, enabling their execution during emulation.

**Constants and Code Maintainability:**

* Replaced hardcoded memory addresses (such as stack and interrupt vector addresses) in `CPU.java` and `CpuInstructionSet.java` with named constants (`STACK_PAGE_START`, `INTERRUPT_VECTOR_LOW`, etc.) for improved readability and maintainability. [[1]](diffhunk://#diff-5cc8c2c04c4805ec0d124aba4287809314271a83af5fc1869425179805190c82L153-R153) [[2]](diffhunk://#diff-5cc8c2c04c4805ec0d124aba4287809314271a83af5fc1869425179805190c82L175-R175) [[3]](diffhunk://#diff-4126581eb998e77ba8eed4be8fbe878262d57c605194218117c4724b771bce77L163-R164) [[4]](diffhunk://#diff-ad506968d280a1e80b36be2ded4b149b937426f78153780a9e2bf2b0f7ce50daR39-R46)
* Added new constants for special values, such as `ACCUMULATOR_SENTINEL`, to clearly indicate special instruction behaviors.

**Addressing Mode Handling:**

* Refined address resolution logic to use `ACCUMULATOR_SENTINEL` for accumulator addressing mode, clarifying instruction intent and simplifying downstream logic.