### PR TITLE
Feat/cycle timing and execution control #24

### DIFF
--- a/src/main/java/dev/omatheusmesmo/selfmat/nes/emulator/core/cpu/CPU.java
+++ b/src/main/java/dev/omatheusmesmo/selfmat/nes/emulator/core/cpu/CPU.java
@@ -1,8 +1,6 @@
 package dev.omatheusmesmo.selfmat.nes.emulator.core.cpu;
 
-import dev.omatheusmesmo.selfmat.nes.emulator.core.cpu.opcode.AddressingMode;
-import dev.omatheusmesmo.selfmat.nes.emulator.core.cpu.opcode.InstructionMetadata;
-import dev.omatheusmesmo.selfmat.nes.emulator.core.cpu.opcode.Opcodes;
+import dev.omatheusmesmo.selfmat.nes.emulator.core.cpu.opcode.*;
 import dev.omatheusmesmo.selfmat.nes.emulator.core.memory.Bus;
 
 import static dev.omatheusmesmo.selfmat.nes.emulator.core.cpu.CpuConstants.*;
@@ -88,10 +86,10 @@ public class CPU {
             throw new IllegalStateException(String.format("Unknown opcode: 0x%02X at PC: 0x%04X", opcode, (programCounter - 1) & MAX_ADDRESS_VALUE));
         }
 
-        int operandAddress = resolveAddress(metadata.addressingMode());
-        instructionSet.execute(metadata, operandAddress); // Delegates execution to CpuInstructionSet which has the dispatcher
+        Operand operand = resolveAddress(metadata.addressingMode());
+        int extraCycles = instructionSet.execute(metadata, operand);
 
-        return metadata.cycles();
+        return metadata.cycles() + extraCycles;
     }
 
     // --- Helper Methods for Memory and Flags (Package-Private for CpuInstructionSet) ---
@@ -149,7 +147,7 @@ public class CPU {
      * The stack is located on memory page 0x01 ($0100 - $01FF).
      * @param data The byte to push onto the stack.
      */
-    void push(byte data) { // Package-private for CpuInstructionSet
+    void push(byte data) { 
         write(STACK_PAGE_START + stackPointer, data);
         stackPointer = (stackPointer - 1) & BYTE_MASK;
     }
@@ -159,7 +157,7 @@ public class CPU {
      * Pushes high byte then low byte.
      * @param address The 16-bit address to push.
      */
-    void pushAddress(int address) { // Package-private for CpuInstructionSet
+    void pushAddress(int address) { 
         push((byte) ((address >> BITS_PER_BYTE) & BYTE_MASK)); // Push high byte
         push((byte) (address & BYTE_MASK)); // Push low byte
     }
@@ -170,7 +168,7 @@ public class CPU {
      * The stack is located on memory page 0x01 ($0100 - $01FF).
      * @return The byte popped from the stack.
      */
-    byte pop() { // Package-private for CpuInstructionSet
+    byte pop() { 
         stackPointer = (stackPointer + 1) & BYTE_MASK;
         return read(STACK_PAGE_START + stackPointer);
     }
@@ -180,7 +178,7 @@ public class CPU {
      * Pops low byte then high byte.
      * @return The 16-bit address popped from the stack.
      */
-    int popAddress() { // Package-private for CpuInstructionSet
+    int popAddress() { 
         int lo = pop() & BYTE_MASK; // Pop low byte
         int hi = pop() & BYTE_MASK; // Pop high byte
         return (hi << BITS_PER_BYTE) | lo;
@@ -193,72 +191,66 @@ public class CPU {
      * based on the specified addressing mode. This method also advances the
      * Program Counter as necessary for multi-byte operands.
      * @param addressingMode The addressing mode to use.
-     * @return The resolved 16-bit effective memory address of the operand.
+     * @return An Operand containing the 16-bit effective memory address and page crossing status.
      */
-    private int resolveAddress(AddressingMode addressingMode) {
+    private Operand resolveAddress(AddressingMode addressingMode) {
         return switch (addressingMode) {
-            case IMMEDIATE -> {
-                int address = programCounter;
-                programCounter = (programCounter + 1) & MAX_ADDRESS_VALUE;
-                yield address;
-            }
-            case ZERO_PAGE -> {
-                yield fetch() & BYTE_MASK;
-            }
+            case IMMEDIATE -> new Operand(programCounter++, false);
+            case ZERO_PAGE -> new Operand(fetch() & BYTE_MASK, false);
             case ABSOLUTE -> {
                 int lo = fetch() & BYTE_MASK;
                 int hi = fetch() & BYTE_MASK;
-                yield (hi << BITS_PER_BYTE) | lo;
+                yield new Operand((hi << BITS_PER_BYTE) | lo, false);
             }
-            case ZERO_PAGE_X -> {
-                int base = fetch() & BYTE_MASK;
-                yield (base + indexX) & BYTE_MASK;
-            }
-            case ZERO_PAGE_Y -> {
-                int base = fetch() & BYTE_MASK;
-                yield (base + indexY) & BYTE_MASK;
-            }
+            case ZERO_PAGE_X -> new Operand((fetch() + indexX) & BYTE_MASK, false);
+            case ZERO_PAGE_Y -> new Operand((fetch() + indexY) & BYTE_MASK, false);
             case ABSOLUTE_X -> {
                 int lo = fetch() & BYTE_MASK;
                 int hi = fetch() & BYTE_MASK;
-                yield (((hi << BITS_PER_BYTE) | lo) + indexX) & MAX_ADDRESS_VALUE;
+                int base = (hi << BITS_PER_BYTE) | lo;
+                int effective = (base + indexX) & MAX_ADDRESS_VALUE;
+                yield new Operand(effective, (base & 0xFF00) != (effective & 0xFF00));
             }
             case ABSOLUTE_Y -> {
                 int lo = fetch() & BYTE_MASK;
                 int hi = fetch() & BYTE_MASK;
-                yield (((hi << BITS_PER_BYTE) | lo) + indexY) & MAX_ADDRESS_VALUE;
+                int base = (hi << BITS_PER_BYTE) | lo;
+                int effective = (base + indexY) & MAX_ADDRESS_VALUE;
+                yield new Operand(effective, (base & 0xFF00) != (effective & 0xFF00));
             }
             case RELATIVE -> {
                 int offset = fetch() & BYTE_MASK;
                 if (offset > SIGNED_BYTE_MAX) offset -= BYTE_WRAP;
-                yield (programCounter + offset) & MAX_ADDRESS_VALUE;
+                int base = programCounter;
+                int effective = (base + offset) & MAX_ADDRESS_VALUE;
+                yield new Operand(effective, (base & 0xFF00) != (effective & 0xFF00));
             }
             case INDIRECT -> {
-                int pointerLo = fetch() & BYTE_MASK;
-                int pointerHi = fetch() & BYTE_MASK;
-                int pointer = (pointerHi << BITS_PER_BYTE) | pointerLo;
+                int lo = fetch() & BYTE_MASK;
+                int hi = fetch() & BYTE_MASK;
+                int pointer = (hi << BITS_PER_BYTE) | lo;
                 int effectiveLo = read(pointer) & BYTE_MASK;
                 // Emulates 6502 JMP Indirect Page Boundary Bug:
                 // if the low byte of the pointer is 0xFF, the high byte is fetched from the start of the current page.
                 int effectiveHi = read((pointer & 0xFF00) | ((pointer + 1) & BYTE_MASK)) & BYTE_MASK;
-                yield (effectiveHi << BITS_PER_BYTE) | effectiveLo;
+                yield new Operand((effectiveHi << BITS_PER_BYTE) | effectiveLo, false);
             }
             case INDIRECT_INDEXED -> {
-                int pointer = fetch() & BYTE_MASK;
-                int baseLo = read(pointer) & BYTE_MASK;
-                int baseHi = read(pointer + 1) & BYTE_MASK;
+                int ptr = fetch() & BYTE_MASK;
+                int baseLo = read(ptr) & BYTE_MASK;
+                int baseHi = read((ptr + 1) & BYTE_MASK) & BYTE_MASK;
                 int baseAddress = (baseHi << BITS_PER_BYTE) | baseLo;
-                yield (baseAddress + indexY) & MAX_ADDRESS_VALUE;
+                int effective = (baseAddress + indexY) & MAX_ADDRESS_VALUE;
+                yield new Operand(effective, (baseAddress & 0xFF00) != (effective & 0xFF00));
             }
             case INDEXED_INDIRECT -> {
                 int pointer = (fetch() + indexX) & BYTE_MASK;
                 int effectiveLo = read(pointer) & BYTE_MASK;
-                int effectiveHi = read(pointer + 1) & BYTE_MASK;
-                yield (effectiveHi << BITS_PER_BYTE) | effectiveLo;
+                int effectiveHi = read((pointer + 1) & BYTE_MASK) & BYTE_MASK;
+                yield new Operand((effectiveHi << BITS_PER_BYTE) | effectiveLo, false);
             }
-            case ACCUMULATOR -> ACCUMULATOR_SENTINEL;
-            // IMPLIED mode is handled by the instruction logic and does not require an operand address.
-            default -> INITIAL_VALUE;
+            case ACCUMULATOR -> new Operand(ACCUMULATOR_SENTINEL, false);
+            default -> new Operand(INITIAL_VALUE, false);
         };
     }
 }

--- a/src/main/java/dev/omatheusmesmo/selfmat/nes/emulator/core/cpu/CpuInstructionSet.java
+++ b/src/main/java/dev/omatheusmesmo/selfmat/nes/emulator/core/cpu/CpuInstructionSet.java
@@ -1,9 +1,6 @@
 package dev.omatheusmesmo.selfmat.nes.emulator.core.cpu;
 
-import dev.omatheusmesmo.selfmat.nes.emulator.core.cpu.opcode.InstructionExecutor;
-import dev.omatheusmesmo.selfmat.nes.emulator.core.cpu.opcode.InstructionMetadata;
-import dev.omatheusmesmo.selfmat.nes.emulator.core.cpu.opcode.Opcodes; // Needed for InstructionMetadata to reference Opcodes.getInstructionMetadata
-import dev.omatheusmesmo.selfmat.nes.emulator.core.cpu.opcode.AddressingMode; // Needed for InstructionMetadata.addressingMode()
+import dev.omatheusmesmo.selfmat.nes.emulator.core.cpu.opcode.*;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -28,6 +25,22 @@ public class CpuInstructionSet {
     public CpuInstructionSet(CPU cpu) {
         this.cpu = cpu;
         setupInstructionExecutors(); // Initialize the instruction dispatch map
+    }
+
+    /**
+     * Executes the instruction defined by the metadata.
+     * Dispatches the call to the appropriate instruction implementation based on the mnemonic.
+     * @param metadata The InstructionMetadata containing the mnemonic.
+     * @param operand The resolved operand containing address and page crossing info.
+     * @return The number of additional CPU cycles consumed.
+     * @throws IllegalStateException if an executor for the mnemonic is not found.
+     */
+    public int execute(InstructionMetadata metadata, Operand operand) {
+        InstructionExecutor executor = instructionExecutors.get(metadata.mnemonic());
+        if (executor == null) {
+            throw new IllegalStateException("Executor not found for instruction: " + metadata.mnemonic());
+        }
+        return executor.execute(operand);
     }
 
     /**
@@ -70,86 +83,101 @@ public class CpuInstructionSet {
 
     // --- Load and Store ---
 
-    public void lda(int operandAddress) {
-        cpu.accumulator = cpu.read(operandAddress) & BYTE_MASK;
+    public int lda(Operand op) {
+        cpu.accumulator = cpu.read(op.address()) & BYTE_MASK;
         updateNegativeAndZeroFlags(cpu.accumulator);
+        return op.pageCrossed() ? 1 : 0; // LDA gains 1 cycle if page is crossed
     }
 
-    public void ldx(int operandAddress) {
-        cpu.indexX = cpu.read(operandAddress) & BYTE_MASK;
+    public int ldx(Operand op) {
+        cpu.indexX = cpu.read(op.address()) & BYTE_MASK;
         updateNegativeAndZeroFlags(cpu.indexX);
+        return op.pageCrossed() ? 1 : 0;
     }
 
-    public void ldy(int operandAddress) {
-        cpu.indexY = cpu.read(operandAddress) & BYTE_MASK;
+    public int ldy(Operand op) {
+        cpu.indexY = cpu.read(op.address()) & BYTE_MASK;
         updateNegativeAndZeroFlags(cpu.indexY);
+        return op.pageCrossed() ? 1 : 0;
     }
 
-    public void sta(int operandAddress) {
-        cpu.write(operandAddress, (byte) (cpu.accumulator & BYTE_MASK));
+    public int sta(Operand op) {
+        cpu.write(op.address(), (byte) (cpu.accumulator & BYTE_MASK));
+        return 0; // STA never adds cycles for page crossing in indexed modes
     }
 
-    public void stx(int operandAddress) {
-        cpu.write(operandAddress, (byte) (cpu.indexX & BYTE_MASK));
+    public int stx(Operand op) {
+        cpu.write(op.address(), (byte) (cpu.indexX & BYTE_MASK));
+        return 0;
     }
 
-    public void sty(int operandAddress) {
-        cpu.write(operandAddress, (byte) (cpu.indexY & BYTE_MASK));
+    public int sty(Operand op) {
+        cpu.write(op.address(), (byte) (cpu.indexY & BYTE_MASK));
+        return 0;
     }
 
     // --- Increment and Decrement ---
 
-    public void inx(int operandAddress) {
+    public int inx(Operand op) {
         cpu.indexX = (cpu.indexX + 1) & BYTE_MASK;
         updateNegativeAndZeroFlags(cpu.indexX);
+        return 0;
     }
 
-    public void dex(int operandAddress) {
+    public int dex(Operand op) {
         cpu.indexX = (cpu.indexX - 1) & BYTE_MASK;
         updateNegativeAndZeroFlags(cpu.indexX);
+        return 0;
     }
 
-    public void iny(int operandAddress) {
+    public int iny(Operand op) {
         cpu.indexY = (cpu.indexY + 1) & BYTE_MASK;
         updateNegativeAndZeroFlags(cpu.indexY);
+        return 0;
     }
 
-    public void dey(int operandAddress) {
+    public int dey(Operand op) {
         cpu.indexY = (cpu.indexY - 1) & BYTE_MASK;
         updateNegativeAndZeroFlags(cpu.indexY);
+        return 0;
     }
 
-    public void inc(int operandAddress) {
-        int value = (cpu.read(operandAddress) + 1) & BYTE_MASK;
-        cpu.write(operandAddress, (byte) value);
+    public int inc(Operand op) {
+        int value = (cpu.read(op.address()) + 1) & BYTE_MASK;
+        cpu.write(op.address(), (byte) value);
         updateNegativeAndZeroFlags(value);
+        return 0;
     }
 
-    public void dec(int operandAddress) {
-        int value = (cpu.read(operandAddress) - 1) & BYTE_MASK;
-        cpu.write(operandAddress, (byte) value);
+    public int dec(Operand op) {
+        int value = (cpu.read(op.address()) - 1) & BYTE_MASK;
+        cpu.write(op.address(), (byte) value);
         updateNegativeAndZeroFlags(value);
+        return 0;
     }
 
     // --- Branches and Jumps ---
 
-    public void jmp(int operandAddress) {
-        cpu.programCounter = operandAddress;
+    public int jmp(Operand op) {
+        cpu.programCounter = op.address();
+        return 0;
     }
 
-    public void jsr(int operandAddress) {
+    public int jsr(Operand op) {
         // Push PC-1 (High then Low)
         int returnAddr = cpu.programCounter - 1;
         cpu.pushAddress(returnAddr); 
-        cpu.programCounter = operandAddress;
+        cpu.programCounter = op.address();
+        return 0;
     }
 
-    public void rts(int operandAddress) {
+    public int rts(Operand op) {
         int returnAddr = cpu.popAddress();
         cpu.programCounter = returnAddr + 1;
+        return 0;
     }
 
-    public void brk(int operandAddress) {
+    public int brk(Operand op) {
         // Push PC+1 (High then Low)
         // BRK is a 2-byte instruction (usually padding byte after opcode), PC has already advanced by 1 in fetch
         cpu.pushAddress(cpu.programCounter); 
@@ -163,220 +191,251 @@ public class CpuInstructionSet {
         int lo = cpu.read(INTERRUPT_VECTOR_LOW) & BYTE_MASK;
         int hi = cpu.read(INTERRUPT_VECTOR_HIGH) & BYTE_MASK;
         cpu.programCounter = (hi << BITS_PER_BYTE) | lo;
+        return 0;
     }
 
     // --- Arithmetic and Logic ---
 
-    public void adc(int operandAddress) {
-        int fetched = cpu.read(operandAddress) & BYTE_MASK;
+    public int adc(Operand op) {
+        int fetched = cpu.read(op.address()) & BYTE_MASK;
         int sum = cpu.accumulator + fetched + (cpu.isFlagSet(CARRY_FLAG) ? 1 : 0);
         
         updateArithmeticFlags(sum, cpu.accumulator, fetched, false);
         cpu.accumulator = sum & BYTE_MASK;
+        return op.pageCrossed() ? 1 : 0;
     }
 
-    public void sbc(int operandAddress) {
-        int fetched = cpu.read(operandAddress) & BYTE_MASK;
+    public int sbc(Operand op) {
+        int fetched = cpu.read(op.address()) & BYTE_MASK;
         // SBC is A - M - (1 - C) -> A + (-M - 1) + C -> A + ~M + C
         int inverted = fetched ^ BYTE_MASK;
         int sum = cpu.accumulator + inverted + (cpu.isFlagSet(CARRY_FLAG) ? 1 : 0);
         
         updateArithmeticFlags(sum, cpu.accumulator, fetched, true);
         cpu.accumulator = sum & BYTE_MASK;
+        return op.pageCrossed() ? 1 : 0;
     }
 
-    public void and(int operandAddress) {
-        cpu.accumulator &= cpu.read(operandAddress) & BYTE_MASK;
+    public int and(Operand op) {
+        cpu.accumulator &= cpu.read(op.address()) & BYTE_MASK;
         updateNegativeAndZeroFlags(cpu.accumulator);
+        return op.pageCrossed() ? 1 : 0;
     }
 
-    public void ora(int operandAddress) {
-        cpu.accumulator |= cpu.read(operandAddress) & BYTE_MASK;
+    public int ora(Operand op) {
+        cpu.accumulator |= cpu.read(op.address()) & BYTE_MASK;
         updateNegativeAndZeroFlags(cpu.accumulator);
+        return op.pageCrossed() ? 1 : 0;
     }
 
-    public void eor(int operandAddress) {
-        cpu.accumulator ^= cpu.read(operandAddress) & BYTE_MASK;
+    public int eor(Operand op) {
+        cpu.accumulator ^= cpu.read(op.address()) & BYTE_MASK;
         updateNegativeAndZeroFlags(cpu.accumulator);
+        return op.pageCrossed() ? 1 : 0;
     }
 
     // --- Stack Operations ---
 
-    public void pha(int operandAddress) {
+    public int pha(Operand op) {
         cpu.push((byte) cpu.accumulator);
+        return 0;
     }
 
-    public void pla(int operandAddress) {
+    public int pla(Operand op) {
         cpu.accumulator = cpu.pop() & BYTE_MASK;
         updateNegativeAndZeroFlags(cpu.accumulator);
+        return 0;
     }
 
-    public void php(int operandAddress) {
+    public int php(Operand op) {
         // PHP always pushes with Break (B) and Unused (U) flags set
         cpu.push((byte) (cpu.statusRegister | BREAK_COMMAND | UNUSED_FLAG));
+        return 0;
     }
 
-    public void plp(int operandAddress) {
+    public int plp(Operand op) {
         // Pull into status, but ignore Unused (U) and Break (B) bits from stack
         // U is always 1, B usually ignored/cleared in register
         int pulled = cpu.pop() & BYTE_MASK;
         cpu.statusRegister = pulled;
         cpu.setFlag(UNUSED_FLAG, true);
         cpu.setFlag(BREAK_COMMAND, false); // B flag does not physically exist in the register
+        return 0;
     }
 
     // Handle Processor Flags
 
-    public void clc(int operandAddress) {
+    public int clc(Operand op) {
         cpu.setFlag(CARRY_FLAG, false);
+        return 0;
     }
 
-    public void sec(int operandAddress) {
+    public int sec(Operand op) {
         cpu.setFlag(CARRY_FLAG, true);
+        return 0;
     }
 
-    public void cld(int operandAddress) {
+    public int cld(Operand op) {
         cpu.setFlag(DECIMAL_MODE, false);
+        return 0;
     }
 
-    public void sed(int operandAddress) {
+    public int sed(Operand op) {
         cpu.setFlag(DECIMAL_MODE, true);
+        return 0;
     }
 
-    public void cli(int operandAddress) {
+    public int cli(Operand op) {
         cpu.setFlag(INTERRUPT_DISABLE, false);
+        return 0;
     }
 
-    public void sei(int operandAddress) {
+    public int sei(Operand op) {
         cpu.setFlag(INTERRUPT_DISABLE, true);
+        return 0;
     }
 
-    public void clv(int operandAddress) {
+    public int clv(Operand op) {
         cpu.setFlag(OVERFLOW_FLAG, false);
+        return 0;
     }
 
-    public void cmp(int operandAddress) {
-        int fetched = cpu.read(operandAddress) & BYTE_MASK;
+    public int cmp(Operand op) {
+        int fetched = cpu.read(op.address()) & BYTE_MASK;
         int result = cpu.accumulator - fetched;
 
         // Set flags based on the comparison
         cpu.setFlag(CARRY_FLAG, cpu.accumulator >= fetched);
         updateNegativeAndZeroFlags(result);
+        return op.pageCrossed() ? 1 : 0;
     }
 
-    public void cpx(int operandAddress) {
-        int fetched = cpu.read(operandAddress) & BYTE_MASK;
+    public int cpx(Operand op) {
+        int fetched = cpu.read(op.address()) & BYTE_MASK;
         int result = cpu.indexX - fetched;
 
         // Set flags based on the comparison
         cpu.setFlag(CARRY_FLAG, cpu.indexX >= fetched);
         updateNegativeAndZeroFlags(result);
+        return 0;
     }
 
-    public void cpy(int operandAddress) {
-        int fetched = cpu.read(operandAddress) & BYTE_MASK;
+    public int cpy(Operand op) {
+        int fetched = cpu.read(op.address()) & BYTE_MASK;
         int result = cpu.indexY - fetched;
 
         // Set flags based on the comparison
         cpu.setFlag(CARRY_FLAG, cpu.indexY >= fetched);
         updateNegativeAndZeroFlags(result);
+        return 0;
     }
 
-    public void tax(int operandAddress) {
+    public int tax(Operand op) {
         cpu.indexX = cpu.accumulator;
         updateNegativeAndZeroFlags(cpu.indexX);
+        return 0;
     }
 
-    public void tay(int operandAddress) {
+    public int tay(Operand op) {
         cpu.indexY = cpu.accumulator;
         updateNegativeAndZeroFlags(cpu.indexY);
+        return 0;
     }
 
-    public void tsx(int operandAddress) {
+    public int tsx(Operand op) {
         cpu.indexX = cpu.stackPointer;
         updateNegativeAndZeroFlags(cpu.indexX);
+        return 0;
     }
 
-    public void txa(int operandAddress) {
+    public int txa(Operand op) {
         cpu.accumulator = cpu.indexX;
         updateNegativeAndZeroFlags(cpu.accumulator);
+        return 0;
     }
 
-    public void tya(int operandAddress) {
+    public int tya(Operand op) {
         cpu.accumulator = cpu.indexY;
         updateNegativeAndZeroFlags(cpu.accumulator);
+        return 0;
     }
 
-    public void txs(int operandAddress) {
+    public int txs(Operand op) {
         cpu.stackPointer = cpu.indexX;
+        return 0;
     }
 
-    public void bit(int operandAddress) {
-        int value = cpu.read(operandAddress) & BYTE_MASK;
+    public int bit(Operand op) {
+        int value = cpu.read(op.address()) & BYTE_MASK;
         cpu.setFlag(NEGATIVE_FLAG, (value & NEGATIVE_FLAG) != INITIAL_VALUE);
         cpu.setFlag(OVERFLOW_FLAG, (value & OVERFLOW_FLAG) != INITIAL_VALUE); // V flag is bit 6 of the operand
         cpu.setFlag(ZERO_FLAG, (cpu.accumulator & value) == INITIAL_VALUE);
+        return 0;
     }
 
-    public void asl(int operandAddress) {
-        if (operandAddress == ACCUMULATOR_SENTINEL) {
+    public int asl(Operand op) {
+        if (op.address() == ACCUMULATOR_SENTINEL) {
             cpu.setFlag(CARRY_FLAG, (cpu.accumulator & NEGATIVE_FLAG) != INITIAL_VALUE);
             cpu.accumulator = (cpu.accumulator << 1) & BYTE_MASK;
             updateNegativeAndZeroFlags(cpu.accumulator);
         } else {
-            int value = cpu.read(operandAddress) & BYTE_MASK;
+            int value = cpu.read(op.address()) & BYTE_MASK;
             cpu.setFlag(CARRY_FLAG, (value & NEGATIVE_FLAG) != INITIAL_VALUE);
             value = (value << 1) & BYTE_MASK;
-            cpu.write(operandAddress, (byte) value);
+            cpu.write(op.address(), (byte) value);
             updateNegativeAndZeroFlags(value);
         }
+        return 0;
     }
 
-    public void lsr(int operandAddress) {
-        if (operandAddress == ACCUMULATOR_SENTINEL) {
+    public int lsr(Operand op) {
+        if (op.address() == ACCUMULATOR_SENTINEL) {
             cpu.setFlag(CARRY_FLAG, (cpu.accumulator & CARRY_FLAG) != INITIAL_VALUE);
             cpu.accumulator = (cpu.accumulator >> 1) & BYTE_MASK;
             updateNegativeAndZeroFlags(cpu.accumulator);
         } else {
-            int value = cpu.read(operandAddress) & BYTE_MASK;
+            int value = cpu.read(op.address()) & BYTE_MASK;
             cpu.setFlag(CARRY_FLAG, (value & CARRY_FLAG) != INITIAL_VALUE);
             value = (value >> 1) & BYTE_MASK;
-            cpu.write(operandAddress, (byte) value);
+            cpu.write(op.address(), (byte) value);
             updateNegativeAndZeroFlags(value);
         }
+        return 0;
     }
 
-    public void rol(int operandAddress) {
+    public int rol(Operand op) {
         boolean oldCarry = cpu.isFlagSet(CARRY_FLAG);
-        if (operandAddress == ACCUMULATOR_SENTINEL) {
+        if (op.address() == ACCUMULATOR_SENTINEL) {
             cpu.setFlag(CARRY_FLAG, (cpu.accumulator & NEGATIVE_FLAG) != INITIAL_VALUE);
             cpu.accumulator = ((cpu.accumulator << 1) | (oldCarry ? 1 : 0)) & BYTE_MASK;
             updateNegativeAndZeroFlags(cpu.accumulator);
         } else {
-            int value = cpu.read(operandAddress) & BYTE_MASK;
+            int value = cpu.read(op.address()) & BYTE_MASK;
             cpu.setFlag(CARRY_FLAG, (value & NEGATIVE_FLAG) != INITIAL_VALUE);
             value = ((value << 1) | (oldCarry ? 1 : 0)) & BYTE_MASK;
-            cpu.write(operandAddress, (byte) value);
+            cpu.write(op.address(), (byte) value);
             updateNegativeAndZeroFlags(value);
         }
+        return 0;
     }
 
-    public void ror(int operandAddress) {
+    public int ror(Operand op) {
         boolean oldCarry = cpu.isFlagSet(CARRY_FLAG);
-        if (operandAddress == ACCUMULATOR_SENTINEL) {
+        if (op.address() == ACCUMULATOR_SENTINEL) {
             cpu.setFlag(CARRY_FLAG, (cpu.accumulator & CARRY_FLAG) != INITIAL_VALUE);
             cpu.accumulator = ((cpu.accumulator >> 1) | (oldCarry ? NEGATIVE_FLAG : 0)) & BYTE_MASK;
             updateNegativeAndZeroFlags(cpu.accumulator);
         } else {
-            int value = cpu.read(operandAddress) & BYTE_MASK;
+            int value = cpu.read(op.address()) & BYTE_MASK;
             cpu.setFlag(CARRY_FLAG, (value & CARRY_FLAG) != INITIAL_VALUE);
             value = ((value >> 1) | (oldCarry ? NEGATIVE_FLAG : 0)) & BYTE_MASK;
-            cpu.write(operandAddress, (byte) value);
+            cpu.write(op.address(), (byte) value);
             updateNegativeAndZeroFlags(value);
         }
+        return 0;
     }
 
-    public void rti(int operandAddress) {
+    public int rti(Operand op) {
         // Pull Status first (but ignore B and U bits)
         int pulledStatus = cpu.pop() & BYTE_MASK;
         cpu.statusRegister = pulledStatus;
@@ -384,13 +443,57 @@ public class CpuInstructionSet {
         cpu.setFlag(BREAK_COMMAND, false); // B flag does not physically exist in the register
 
         // Then pull PC (Low then High)
-        int lo = cpu.pop() & BYTE_MASK;
-        int hi = cpu.pop() & BYTE_MASK;
-        cpu.programCounter = (hi << BITS_PER_BYTE) | lo;
+        cpu.programCounter = cpu.popAddress();
+        return 0;
     }
 
-    public void nop(int operandAddress) {
+    public int nop(Operand op) {
         // No operation - do nothing
+        return 0;
+    }
+
+    private int branchIf(boolean condition, Operand op){
+        if (condition) {
+            int extraCycles = 1;
+            if (op.pageCrossed()) {
+                extraCycles++;
+            }
+            cpu.programCounter = op.address();
+            return extraCycles;
+        }
+        return 0;
+    }
+
+    public int bne(Operand op) {
+        return branchIf(!cpu.isFlagSet(ZERO_FLAG), op);
+    }
+
+    public int beq(Operand op) {
+        return branchIf(cpu.isFlagSet(ZERO_FLAG), op);
+    }
+
+    public int bpl(Operand op) {
+        return branchIf(!cpu.isFlagSet(NEGATIVE_FLAG), op);
+    }
+
+    public int bmi(Operand op) {
+        return branchIf(cpu.isFlagSet(NEGATIVE_FLAG), op);
+    }
+
+    public int bvc(Operand op) {
+        return branchIf(!cpu.isFlagSet(OVERFLOW_FLAG), op);
+    }
+
+    public int bvs(Operand op) {
+        return branchIf(cpu.isFlagSet(OVERFLOW_FLAG), op);
+    }
+
+    public int bcc(Operand op) {
+        return branchIf(!cpu.isFlagSet(CARRY_FLAG), op);
+    }
+
+    public int bcs(Operand op) {
+        return branchIf(cpu.isFlagSet(CARRY_FLAG), op);
     }
 
     // --- Dispatching Logic ---
@@ -471,20 +574,15 @@ public class CpuInstructionSet {
 
         // No Operation
         instructionExecutors.put("NOP", this::nop);
-    }
 
-    /**
-     * Executes the instruction defined by the metadata.
-     * Dispatches the call to the appropriate instruction implementation based on the mnemonic.
-     * @param metadata The InstructionMetadata containing the mnemonic.
-     * @param operandAddress The resolved memory address for the operand.
-     * @throws IllegalStateException if an executor for the mnemonic is not found.
-     */
-    public void execute(InstructionMetadata metadata, int operandAddress) {
-        InstructionExecutor executor = instructionExecutors.get(metadata.mnemonic());
-        if (executor == null) {
-            throw new IllegalStateException("Executor not found for instruction: " + metadata.mnemonic() + " (Opcode: " + metadata.cycles() + ")");
-        }
-        executor.execute(operandAddress);
+        // Branch Instructions
+        instructionExecutors.put("BNE", this::bne);
+        instructionExecutors.put("BEQ", this::beq);
+        instructionExecutors.put("BPL", this::bpl);
+        instructionExecutors.put("BMI", this::bmi);
+        instructionExecutors.put("BVC", this::bvc);
+        instructionExecutors.put("BVS", this::bvs);
+        instructionExecutors.put("BCC", this::bcc);
+        instructionExecutors.put("BCS", this::bcs);
     }
 }

--- a/src/main/java/dev/omatheusmesmo/selfmat/nes/emulator/core/cpu/opcode/InstructionExecutor.java
+++ b/src/main/java/dev/omatheusmesmo/selfmat/nes/emulator/core/cpu/opcode/InstructionExecutor.java
@@ -3,5 +3,10 @@ package dev.omatheusmesmo.selfmat.nes.emulator.core.cpu.opcode;
 @FunctionalInterface
 public interface InstructionExecutor {
 
-    void execute(int operandAddress);
+    /**
+     * Executes the instruction logic.
+     * @param operand The resolved operand containing address and page crossing info.
+     * @return The number of additional CPU cycles consumed (e.g., branch taken, page crossing).
+     */
+    int execute(Operand operand);
 }

--- a/src/main/java/dev/omatheusmesmo/selfmat/nes/emulator/core/cpu/opcode/Operand.java
+++ b/src/main/java/dev/omatheusmesmo/selfmat/nes/emulator/core/cpu/opcode/Operand.java
@@ -1,0 +1,9 @@
+package dev.omatheusmesmo.selfmat.nes.emulator.core.cpu.opcode;
+
+/**
+ * Represents an operand for a 6502 instruction.
+ * Contains the resolved effective address and whether a page boundary was crossed
+ * during address resolution.
+ */
+public record Operand(int address, boolean pageCrossed) {
+}


### PR DESCRIPTION
Fixes #24 

# Summary (Copilot)

This pull request refactors the NES emulator CPU core to improve operand handling and instruction execution, making the codebase more extensible and accurate. The main changes include introducing an `Operand` type to encapsulate address and page-crossing information, updating instruction methods to use this type, and modifying the instruction execution pipeline to return extra cycles when a page boundary is crossed.

Key changes:

**Operand Handling and Address Resolution:**

- Refactored the `resolveAddress` method in `CPU.java` to return an `Operand` object containing both the effective memory address and a flag indicating if a page boundary was crossed, instead of just an address. This enables more accurate CPU cycle emulation for certain instructions.

**Instruction Execution Pipeline:**

- Updated the instruction dispatch system in `CpuInstructionSet.java`:
  - Instruction executor methods now accept an `Operand` and return the number of extra cycles consumed (e.g., due to page crossing), rather than being `void` methods.
  - Added a new `execute` method that dispatches instructions based on metadata and returns any additional cycles.
  - The `CPU.step()` method now sums the base cycles from the instruction metadata with any extra cycles returned by the executor.

**API and Access Modifiers:**

- Removed package-private comments from stack operation methods (`push`, `pop`, `pushAddress`, `popAddress`) in `CPU.java`, making their visibility clearer and consistent. [[1]](diffhunk://#diff-5cc8c2c04c4805ec0d124aba4287809314271a83af5fc1869425179805190c82L152-R150) [[2]](diffhunk://#diff-5cc8c2c04c4805ec0d124aba4287809314271a83af5fc1869425179805190c82L162-R160) [[3]](diffhunk://#diff-5cc8c2c04c4805ec0d124aba4287809314271a83af5fc1869425179805190c82L173-R171) [[4]](diffhunk://#diff-5cc8c2c04c4805ec0d124aba4287809314271a83af5fc1869425179805190c82L183-R181)

**Code Simplification and Import Cleanup:**

- Consolidated opcode-related imports using wildcard imports in both `CPU.java` and `CpuInstructionSet.java` for brevity and maintainability. [[1]](diffhunk://#diff-5cc8c2c04c4805ec0d124aba4287809314271a83af5fc1869425179805190c82L3-R3) [[2]](diffhunk://#diff-4126581eb998e77ba8eed4be8fbe878262d57c605194218117c4724b771bce77L3-R3)

These changes make the CPU emulation more accurate and the code easier to maintain and extend for future instruction set improvements.